### PR TITLE
Install artifacts using cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,43 @@
 cmake_minimum_required(VERSION 3.9)
-project(imutils_cpp VERSION 1.0.1 DESCRIPTION "imutils_cpp A series of convenience functions to make basic image processing functions such as translation, rotation, resizing and skeletonization easier with OpenCV ")
+project(imutils_cpp
+        LANGUAGES CXX
+        VERSION 1.0.1
+        DESCRIPTION "imutils_cpp A series of convenience functions to make basic image processing functions such as translation, rotation, resizing and skeletonization easier with OpenCV "
+)
+
+include(GNUInstallDirs)
+
 find_package(OpenCV REQUIRED)
-include(GNUInstallDirs)
-add_library(imutils_cpp SHARED STATIC src/text.cpp include/imutils/text.h src/paths.cpp include/imutils/paths.h src/perspective.cpp include/imutils/perspective.h src/convenience.cpp include/imutils/convenience.h)
-set_target_properties(imutils_cpp PROPERTIES VERSION ${PROJECT_VERSION})
-target_include_directories(imutils_cpp PRIVATE include)
-target_include_directories(imutils_cpp PRIVATE src)
-include(GNUInstallDirs)
-install(TARGETS imutils_cpp
-        ${PROJECT_NAME}
-        DESTINATION lib/${PROJECT_NAME})
-target_link_libraries(imutils_cpp ${OpenCV_LIBS} curl)
+find_package(CURL REQUIRED)
+
+if (MSVC AND BUILD_SHARED_LIBS)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+endif()
+
+add_library(${PROJECT_NAME} src/text.cpp src/paths.cpp src/perspective.cpp src/convenience.cpp)
+set(IMUTILS_HEADERS include/imutils/text.h include/imutils/paths.h include/imutils/perspective.h include/imutils/convenience.h)
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    PUBLIC_HEADER "${IMUTILS_HEADERS}"
+)
+target_link_libraries(imutils_cpp opencv_core opencv_imgcodecs opencv_imgproc CURL::libcurl)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+if (MSVC)
+  target_compile_options(imutils_cpp PRIVATE "/permissive-")
+endif()
+target_compile_options(imutils_cpp PRIVATE "-Wall")
+target_include_directories(${PROJECT_NAME} PRIVATE include)
+target_include_directories(${PROJECT_NAME} PRIVATE src)
+
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/imutils
+)
+
+install(EXPORT ${PROJECT_NAME}Targets
+        NAMESPACE imutils_cpp::
+        DESTINATION lib/cmake
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 if (MSVC)
   target_compile_options(imutils_cpp PRIVATE "/permissive-")
 endif()
-target_compile_options(imutils_cpp PRIVATE "-Wall")
 target_include_directories(${PROJECT_NAME} PRIVATE include)
 target_include_directories(${PROJECT_NAME} PRIVATE src)
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ for(std::string file:dirs){
 </pre>
 
 <a name="Installation">
- 
+
 ## Installation
 
 </a>
@@ -154,13 +154,23 @@ for(std::string file:dirs){
 This library is dependent on [opencv](https://github.com/opencv/opencv) and [curl](https://github.com/curl/curl)
 libraries
 
+### Build from source and install in your system
+
+<pre>
+$ cd imutils-cpp/
+$ mkdir build && cd build/
+$ cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
+$ cmake --build .
+$ sudo cmake --build . --target install
+</pre>
+
 ### Dynamic Library for local use
 
-<pre> 
+<pre>
 $ cp /home/usr/Download/libimutils_cpp.so /home/usr/lib
 </pre>
 or
-<pre> 
+<pre>
 $ cp /usr/Download/libimutils_cpp.so.1.0.1 /usr/lib
 $ ldconfig -n -v /usr/lib
 </pre>


### PR DESCRIPTION
- It uses std::filesystem, which requires C++17
- Export all symbols when building on Windows + shared library to generate a .dll
- Generate imutils_cppTargets.cmake with `imutils_cpp::imutils_cpp` target
- Add support to install the library by cmake
- Update README with how to build